### PR TITLE
Fixes for gnome-shell 40-42

### DIFF
--- a/threefingerwindowmove@do.sch.dev.gmail.com/metadata.json
+++ b/threefingerwindowmove@do.sch.dev.gmail.com/metadata.json
@@ -3,5 +3,5 @@
 	"description": "Allows moving windows around with a three finger trackpad gesture (Wayland only)", 
 	"url": "https://github.com/do-sch/gnome-shell-touchpad-window-move",
 	"uuid": "threefingerwindowmove@do.sch.dev.gmail.com",
-	"shell-version": ["3.32", "3.34", "3.36", "3.38"]
+	"shell-version": ["3.32", "3.34", "3.36", "3.38", "40", "41", "42"]
 }

--- a/threefingerwindowmove@do.sch.dev.gmail.com/prefs.js
+++ b/threefingerwindowmove@do.sch.dev.gmail.com/prefs.js
@@ -13,7 +13,10 @@ function buildPrefsWidget() {
     let frame = new Gtk.Frame();
     frame.set_label("Gesture Options");
     frame.set_valign(Gtk.Align.START);
-    frame.margin = 20;
+    frame.set_margin_top(20);
+    frame.set_margin_bottom(20);
+    frame.set_margin_start(20);
+    frame.set_margin_end(20);
 
     // Grid to place all the widgets
     let layout = new Gtk.Grid({
@@ -21,9 +24,12 @@ function buildPrefsWidget() {
         column_spacing: 20,
         row_homogeneous: true,
         row_spacing: 5,
-        margin: 20
+        margin_top: 20,
+        margin_bottom: 20,
+        margin_start: 20,
+        margin_end: 20
     });
-    frame.add(layout);
+    frame.set_child(layout);
     
     // Widgets
     let accelLabel = new Gtk.Label({label: "Acceleration"});
@@ -78,7 +84,7 @@ function buildPrefsWidget() {
     layout.attach(summarizeLabel, 0, 2, 1, 1);
     layout.attach(summarizeSwitch, 1, 2, 1, 1);
     
-    frame.show_all();
+    //frame.show_all();
     return frame;
 }
 

--- a/threefingerwindowmove@do.sch.dev.gmail.com/swipe3to4.py
+++ b/threefingerwindowmove@do.sch.dev.gmail.com/swipe3to4.py
@@ -1,0 +1,21 @@
+#reassign existing gnome gestures from 3 to 4 fingers
+#run with sudo
+
+#from https://github.com/icedman/gnome-shell-hammer/blob/master/shell/swipe3to4.py
+
+f=open("/usr/lib/gnome-shell/libgnome-shell.so","rb")
+s=f.read()
+f.close()
+
+# gesture
+s=s.replace(b'GESTURE_FINGER_COUNT\x20=\x203',b'GESTURE_FINGER_COUNT\x20=\x204')
+
+# radius .. 30px ick
+s=s.replace(b'RADIUS_PIXELS\x20=\x2030',b'RADIUS_PIXELS\x20=\x2010')
+
+# overview startup animation
+s=s.replace(b'Main.panel.style\x20=\x20\'tr',b'callback();\x20return;\x20//')
+
+f=open("libgnome-shell-replaced.so","wb")
+f.write(s)
+f.close()


### PR DESCRIPTION
Made a few changes that should fix compatibility with Gnome versions 40-42 (specifically the preferences weren't opening for me under Ubuntu 22.04 LTS, after adding my gnome-shell version in metadata.json). Also added a Python script to change current three finger gestures to respond to four fingers (courtesy of icedman's gnome-shell-hammer project).